### PR TITLE
Resolved #453. Hide icon in last frame of track

### DIFF
--- a/src/main/java/app/gpx_animator/core/renderer/Renderer.java
+++ b/src/main/java/app/gpx_animator/core/renderer/Renderer.java
@@ -527,8 +527,8 @@ public final class Renderer {
     }
 
     private void keepFrame(@NonNull final List<RendererPlugin> plugins, @NonNull final RenderingContext rc,
-                               @NonNull final FrameWriter frameWriter, @Nullable final BufferedImage bi, final int frames,
-                               @NonNull final TreeMap<Long, Point2D> wpMap, @Nullable final Long keepFrame) throws UserException {
+                           @NonNull final FrameWriter frameWriter, @Nullable final BufferedImage bi, final int frames,
+                           @NonNull final TreeMap<Long, Point2D> wpMap, @Nullable final Long keepFrame) throws UserException {
         if (bi != null && keepFrame != null && keepFrame > 0) {
             drawWaypoints(bi, frames, wpMap);
             final var marker = drawMarker(bi, frames);
@@ -668,22 +668,17 @@ public final class Renderer {
         final var t2 = getTime(frame);
         final var trackConfigurationList = cfg.getTrackConfigurationList();
 
-        var i = 0;
         var trackIdx = 0;
         outer:
-        for (final var timePointMapList : timePointMapListList) {
-            final var trackConfiguration = trackConfigurationList.get(i++);
+        for (int i = 0; i < timePointMapListList.size(); i++) {
+            var timePointMapList = timePointMapListList.get(i);
+            final var trackConfiguration = trackConfigurationList.get(i);
             for (final var timePointMap : timePointMapList) {
                 final var interpolator = interpolators.get(trackIdx++);
                 final var ceilingEntry = timePointMap.ceilingEntry(t2);
                 point = interpolator.getPointAtTime(t2);
                 if (point == null) {
-                    final var floorEntry = timePointMap.floorEntry(t2);
-                    if (floorEntry == null) {
-                        continue;
-                    } else {
-                        point = floorEntry.getValue();
-                    }
+                    continue;
                 }
 
                 g2.setColor(ceilingEntry == null ? Color.white : trackConfiguration.getColor());


### PR DESCRIPTION
Added `--one-icon-for-multi-tracks` option for hide icon for not lastested tracks.

Without `--one-icon-for-multi-tracks`: 
![28 10 22-without-opt](https://user-images.githubusercontent.com/2463361/202370498-92c5c554-d45a-4fab-ba36-caf565125906.gif)
https://user-images.githubusercontent.com/2463361/202369854-0392275b-f403-42ba-b60e-e1350f20eb64.mp4

With: `--one-icon-for-multi-tracks`:
![28 10 22-with-opt](https://user-images.githubusercontent.com/2463361/202370525-6a62edd5-4949-4118-a2ac-541c9bd028c3.gif)
https://user-images.githubusercontent.com/2463361/202369393-c08583a3-ac81-40c6-af38-60615bb927a8.mp4


Also, fixed a test with asserts output file size and suppressed old warnings from SpotBugs for commit.
