### PR TITLE
change formatting of time of photo to include minutes

### DIFF
--- a/src/main/java/app/gpx_animator/core/renderer/plugins/PhotoPlugin.java
+++ b/src/main/java/app/gpx_animator/core/renderer/plugins/PhotoPlugin.java
@@ -22,6 +22,7 @@ import app.gpx_animator.core.preferences.Preferences;
 import app.gpx_animator.core.renderer.Metadata;
 import app.gpx_animator.core.renderer.RenderingContext;
 import app.gpx_animator.core.renderer.framewriter.FrameWriter;
+import app.gpx_animator.core.util.DateUtil;
 import app.gpx_animator.core.util.RenderUtil;
 import app.gpx_animator.core.util.Utils;
 import com.drew.imaging.ImageMetadataReader;
@@ -65,7 +66,7 @@ public final class PhotoPlugin implements RendererPlugin {
 
     static {
         final var dateTime = ZonedDateTime.now();
-        final var formatter = DateTimeFormatter.ofPattern("xxx"); //NON-NLS
+        final var formatter = DateTimeFormatter.ofPattern("x"); //NON-NLS
         SYSTEM_ZONE_OFFSET = dateTime.format(formatter);
     }
 
@@ -158,8 +159,7 @@ public final class PhotoPlugin implements RendererPlugin {
                 : SYSTEM_ZONE_OFFSET;
         final var dateTimeString = directory.getString(ExifDirectoryBase.TAG_DATETIME_ORIGINAL)
                 .concat(" ").concat(zoneOffset.replace(":", ""));
-        final var zonedDateTime = ZonedDateTime.parse(dateTimeString,
-                DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss xxx")); //NON-NLS
+        final var zonedDateTime = DateUtil.parseZonedDateTime(dateTimeString);
         return zonedDateTime.toEpochSecond() * 1_000;
     }
 

--- a/src/main/java/app/gpx_animator/core/renderer/plugins/PhotoPlugin.java
+++ b/src/main/java/app/gpx_animator/core/renderer/plugins/PhotoPlugin.java
@@ -65,7 +65,7 @@ public final class PhotoPlugin implements RendererPlugin {
 
     static {
         final var dateTime = ZonedDateTime.now();
-        final var formatter = DateTimeFormatter.ofPattern("x"); //NON-NLS
+        final var formatter = DateTimeFormatter.ofPattern("xxx"); //NON-NLS
         SYSTEM_ZONE_OFFSET = dateTime.format(formatter);
     }
 
@@ -159,7 +159,7 @@ public final class PhotoPlugin implements RendererPlugin {
         final var dateTimeString = directory.getString(ExifDirectoryBase.TAG_DATETIME_ORIGINAL)
                 .concat(" ").concat(zoneOffset.replace(":", ""));
         final var zonedDateTime = ZonedDateTime.parse(dateTimeString,
-                DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss x")); //NON-NLS
+                DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss xxx")); //NON-NLS
         return zonedDateTime.toEpochSecond() * 1_000;
     }
 


### PR DESCRIPTION
this is for the issue #472 

I think it worked before only when there were no TAG_TIME_ZONE_ORIGINAL in the metadata of the photo set, then the current time is used and also parsed with just 'x' using only the hours. The TAG_TIME_ZONE_ORIGINAL includes minutes though and needs 'xxx' for parsing, that's why i changed the SYSTEM_ZONE_OFFSET to also include minutes through parsing with 'xxx'.