### PR TITLE
fix npe from photo freeze time when loading old config

### DIFF
--- a/src/main/java/app/gpx_animator/core/configuration/Configuration.java
+++ b/src/main/java/app/gpx_animator/core/configuration/Configuration.java
@@ -128,7 +128,7 @@ public final class Configuration {
 
     @XmlJavaTypeAdapter(FileXmlAdapter.class)
     private File photoDirectory;
-    private Long photoFreezeFrameTime;
+    private Long photoFreezeFrameTime = 0L;
     private Long photoTime;
     private Long photoAnimationDuration = DEFAULT_PHOTO_ANIMATION_DURATION;
 


### PR DESCRIPTION
i reproduced the error with an old configuration and after setting the value to 0L rendering worked. for #639 