### PR TITLE
Add a How to contribute section to the website #220

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,6 +449,19 @@
 
         <p>Please be patient. This is a private project, I'm working on in my rare spare time.</p>
 
+        <h2 id="contribute">How to contribute</h2>
+
+        <p>
+            Bug reports, ideas, and pull requests are welcome.
+            The README has a <a href="https://github.com/gpx-animator/gpx-animator#contributing">Contributing</a>
+            section with good first issues, a Gitpod workspace, and build/run/test commands.
+        </p>
+        <ul>
+            <li>Fork the <a href="https://github.com/gpx-animator/gpx-animator">repository</a> and open a pull request against <code>master</code></li>
+            <li>Start with a <a href="https://github.com/gpx-animator/gpx-animator/contribute">good first issue</a> if you are new here</li>
+            <li>Join <a href="https://jugch.slack.com/">Slack channel #gpx-animator</a> (register at <a href="http://slack.jug.ch/">slack.jug.ch</a> first) if you want to talk through a change</li>
+        </ul>
+
         <h2 id="contributors">Contributors</h2>
 
         <p>


### PR DESCRIPTION
The README already has a Contributing section. This adds a matching How to contribute section on the website.

Closes #220
